### PR TITLE
[63383] REMOVE: Unused vulnerable packages

### DIFF
--- a/Ofqual.Recognition.Frontend.Core/Ofqual.Recognition.Frontend.Core.csproj
+++ b/Ofqual.Recognition.Frontend.Core/Ofqual.Recognition.Frontend.Core.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.0" />
 	  <PackageReference Include="Microsoft.Identity.Web" Version="4.14.2" />
   </ItemGroup>
 

--- a/Ofqual.Recognition.Frontend.Infrastructure/Ofqual.Recognition.Frontend.Infrastructure.csproj
+++ b/Ofqual.Recognition.Frontend.Infrastructure/Ofqual.Recognition.Frontend.Infrastructure.csproj
@@ -7,9 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="5.0.17" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.6" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Serilog" Version="4.3.0" />

--- a/Ofqual.Recognition.Frontend.Tests/Ofqual.Recognition.Frontend.Tests.csproj
+++ b/Ofqual.Recognition.Frontend.Tests/Ofqual.Recognition.Frontend.Tests.csproj
@@ -16,11 +16,8 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.v3.assert" Version="3.2.2" />
+    <PackageReference Include="xunit.v3.extensibility.core" Version="3.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Ofqual.Recognition.Frontend.Web/Ofqual.Recognition.Frontend.Web.csproj
+++ b/Ofqual.Recognition.Frontend.Web/Ofqual.Recognition.Frontend.Web.csproj
@@ -11,16 +11,10 @@
   <ItemGroup>
     <PackageReference Include="CorrelationId" Version="3.0.1" />
     <PackageReference Include="GovUk.Frontend.AspNetCore" Version="3.2.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.17" />
-    <PackageReference Include="Microsoft.Extensions.Caching.SqlServer" Version="8.0.22" />
-    <PackageReference Include="Microsoft.Identity.Web" Version="4.14.2" />
-    <PackageReference Include="Serilog" Version="4.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.SqlServer" Version="10.0.11" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
-    <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
-    <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageReference Include="Serilog.Sinks.Http.LogzIo" Version="3.0.0" />
-    <PackageReference Include="System.Drawing.Common" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Changes made:

* Upgrade xunit packages to xunit.v3 - v2 is now deprecated
* Upgrade Microsoft.Extensions.Caching.SqlServer to v10.0.11 - this eliminates the system.drawing dependency that currently contains the critical vulnerability.
* Removed packages that were considered redundant. - playwright project was left unchanged as some of those dependencies are required during test build in pipeline.
